### PR TITLE
Updated Grunt to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Check for circular dependencies in AMD or CommonJS modules using Madge.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`
+This plugin requires Grunt `~1.0.1`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"madge": "~0.5.0"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": "~1.0.1"
 	},
 	"keywords": [
 		"gruntplugin"


### PR DESCRIPTION
Since `grunt` was already released in version 1.0.1, I think it would be good if this plugin would be able to use it